### PR TITLE
U/emoral435/feat/fix react typed container min width and added project types

### DIFF
--- a/src/app/client.tsx
+++ b/src/app/client.tsx
@@ -11,33 +11,34 @@ import { useState, useEffect } from "react"
 import getStaticProps from "../lib/getStaticProps.ts"
 import { ToggleDarkMode } from "../lib/ColorContext.tsx"
 
+import type { projectNode } from '../lib/constants.ts'
+
 function Home() {
   const [isFetching, setIsFetching] = useState<boolean>(true)
   const [isLoading, setIsLoading] = useState<boolean>(true)
-  const [projects, setProjects] = useState<any>([])
+  const [projects, setProjects] = useState<projectNode[]>([])
 
   useEffect(() => {
-  async function fetchAPI() {
-    try {
-      const result = await getStaticProps()
-      setIsFetching(false)
-      setProjects(result.pinnedItems)
-    } catch (error) {
-      setIsFetching(false)
-      console.log({ERROR: error})
+    async function fetchAPI() {
+      try {
+        const result = await getStaticProps()
+        setIsFetching(false)
+        setProjects(result.pinnedItems)
+      } catch (error) {
+        setIsFetching(false)
+        console.log({ERROR: error})
+      }
     }
-  }
-  fetchAPI()
+    fetchAPI()
   
     // Check if the page has already loaded
     setTimeout(() => {
-    setIsLoading(false)
-    console.log("Hello! If you are reading this, you either are a software engineer, recruiter, or just know your way around the console! Feel free to look around.")
+      setIsLoading(false)
+      console.log("Hello! If you are reading this, you either are a software engineer, recruiter, or just know your way around the console! Feel free to look around.")
     }, 750)
-
-  return () => {
-    document.getElementById("loading-modal")?.classList.add("hidden")
-  }
+    return () => {
+      document.getElementById("loading-modal")?.classList.add("hidden")
+    }
   }, [])
 
   
@@ -52,7 +53,7 @@ function Home() {
           <Toolbar />
           <Box sx={{ marginTop: '3.2rem', display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', gap: {xs: '3rem',md: '5rem'}}} >
             <Introduction />
-            <Information projects={projects} id="projects" />
+            <Information projects={projects} />
           </Box>
         </Box>
         <Footer />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ const roboto = Roboto_Mono({
     subsets: ['latin'],
 })
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const metadata: Metadata = {
     title: 'Eduardo Morales',
     description: 'Hello! Welcome to my corner of the web.',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import '../index.css'
 import { ClientOnly } from './client'
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function generateStaticParams() {
   return [{ slug: [''] }]
 }

--- a/src/components/Information/Information.tsx
+++ b/src/components/Information/Information.tsx
@@ -3,9 +3,14 @@ import Experience from './Experience';
 import Projects from './Projects';
 import { Box } from '@mui/material';
 
-// BG COLOR : backgroundColor: '#3f50b5', 
+import type { projectNode } from '../../lib/constants';
 
-export default function Information({ projects } : any) {
+
+interface informationProps {
+  projects: projectNode[]
+}
+
+export default function Information({ projects } : informationProps) {
 
   return (
     <Box component={'div'} sx={{width: {xs: '100%', lg: '80rem'}}}>

--- a/src/components/Information/Projects.tsx
+++ b/src/components/Information/Projects.tsx
@@ -1,8 +1,13 @@
 import { Accordion, AccordionDetails, AccordionSummary, Box, Typography } from '@mui/material';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import ProjectBox from '../Project/Project';
+import { projectNode } from '../../lib/constants';
 
-const Projects = ({projects}:any) => {
+interface projectsProps {
+  projects: projectNode[]
+}
+
+const Projects = ({ projects } : projectsProps) => {
 	return (
 		<Accordion id='Projects' style={{ boxShadow: "none" }} >
 				<AccordionSummary
@@ -20,7 +25,7 @@ const Projects = ({projects}:any) => {
 				{
 				projects ?
 					<Box className="grid-container grid-project-fit" sx={{gap: '3rem', alignItems: 'center'}}>
-						{projects.length > 0 && projects.map((project : any) =>(
+						{projects.length > 0 && projects.map((project : projectNode) =>(
 						<ProjectBox project={project} key={project.name} />
 						))}
 					</Box>

--- a/src/components/Introduction/Introduction.tsx
+++ b/src/components/Introduction/Introduction.tsx
@@ -20,8 +20,8 @@ const Introduction = () => {
 					<Image src={PROFILEGIF} alt="Candid photo of myself" className="profile-pic"/>
 				</Box>
 			</Box>
-			<Box component={'section'} sx={{maxWidth: 'min-content'}}>
-				<Box sx={{paddingLeft: 3 ,textAlign: 'center', whiteSpace: 'nowrap' ,fontWeight: 700 ,fontSize: {xs: '3.7rem',sm: '4.5rem', md: '6.5rem'}}}>
+			<Box component={'section'}>
+				<Box sx={{paddingLeft: 3 ,textAlign: 'center', whiteSpace: 'nowrap' ,fontWeight: 700 ,fontSize: {xs: '3.7rem',sm: '4.5rem', md: '6rem'}}}>
 					<ReactTyped strings={[introInfo.floatingText]} typeSpeed={110} className="typed" />
 				</Box>
 				<Box component={'h2'} sx={{textAlign: 'center' ,color: theme.palette.text.secondary, fontWeight: 700, fontSize: {xs: '1rem', sm: '1.22rem', md: '1.7rem'}}}>

--- a/src/components/Project/Project.tsx
+++ b/src/components/Project/Project.tsx
@@ -5,6 +5,7 @@ import StarIcon from '@mui/icons-material/Star';
 import { useTheme } from "@mui/material/styles";
 import { useEffect, useState } from "react";
 import Badge from "../Badge/Badge";
+import { projectLanguages, projectNode, projectRepositoryTopics } from "../../lib/constants";
 
 function getDarkColor() {
     let color = '#';
@@ -14,27 +15,31 @@ function getDarkColor() {
     return color;
 }
 
-
-interface PropInterface {
-    project: any
+type PropInterface = {
+    project: projectNode,
 }
-
 
 const ProjectBox = ({project} : PropInterface) => {
     const theme = useTheme()
-    const [technology, setTechnologies] = useState<any>([])
-    const [languages, setLanguage] = useState<any>([])
+    const [technology, setTechnologies] = useState<projectRepositoryTopics[]>([])
+    const [languages, setLanguage] = useState<projectLanguages[]>([])
 
     useEffect(() => {
         if (project.repositoryTopics.nodes.length) {
-			project.repositoryTopics.nodes = project.repositoryTopics.nodes.length > 5 ? project.repositoryTopics.nodes.slice(0, 6) : project.repositoryTopics.nodes
-            setTechnologies(project.repositoryTopics.nodes)
+            if (project.repositoryTopics.nodes.length > 5) {
+                setTechnologies(project.repositoryTopics.nodes.slice(0, 6))
+            } else {
+                setTechnologies(project.repositoryTopics.nodes)
+            }
         }
         if (project.languages.nodes.length) {
-			project.languages.nodes = project.languages.nodes.length > 3 ? project.languages.nodes.slice(0, 3) : project.languages.nodes
-            setLanguage(project.languages.nodes)
+            if (project.languages.nodes.length > 3) {
+                setLanguage(project.languages.nodes.slice(0, 3))
+            } else {
+                setLanguage(project.languages.nodes)
+            }
         }
-    }, [])
+    }, [project.repositoryTopics.nodes, project.languages.nodes])
 
   return (
     <Box key={project.name} sx={{display: 'flex', flexDirection: 'column', gap: '.5rem', }} className='project' >
@@ -53,7 +58,7 @@ const ProjectBox = ({project} : PropInterface) => {
             <section  style={{color: '#d9b63c', display: 'flex', flexDirection: 'column'}} >
                 <h3>Topics</h3>
                 <Box className="grid-container grid-tech-fit" sx={{gap: '.3rem', alignItems: 'center', padding: '.5rem'}}>
-                    {technology.map( (item : any) => (
+                    {technology.map( (item : projectRepositoryTopics) => (
                         <div key={item.topic.name} >
                             <Badge text={item.topic.name} color ={getDarkColor()} textColor={'white'} />
                         </div>
@@ -65,7 +70,7 @@ const ProjectBox = ({project} : PropInterface) => {
             <section style={{color: '#d9b63c', display: 'flex', flexDirection: 'column', alignContent: 'center'}} >
                 <h3>Languages</h3>
                 <Box className="grid-container grid-tech-fit" sx={{gap: '.3rem', alignItems: 'center', padding: '.5rem'}}>
-                    {languages.map( (item : any) => (
+                    {languages.map( (item : projectLanguages) => (
                         <div key={item.name} >
                             <Badge  text={item.name} color ={item.color} textColor={'black'} />
                         </div>

--- a/src/lib/ColorContext.tsx
+++ b/src/lib/ColorContext.tsx
@@ -1,5 +1,5 @@
 import { createTheme, ThemeProvider } from "@mui/material";
-import { ReactElement, createContext, useMemo, useState, useEffect } from "react";
+import { ReactElement, createContext, useMemo, useState } from "react";
 
 
 interface Children {
@@ -10,16 +10,13 @@ interface Children {
 export const ColorModeContext = createContext({ toggleColorMode: () => { undefined }})
 
 export const ToggleDarkMode = ({ children } : Children) => {
-    let defaultColorMode = "dark"
+    let defaultColorMode: 'light' | 'dark' = "dark"
+    // https://stackoverflow.com/questions/56393880/how-do-i-detect-dark-mode-using-javascript
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+        defaultColorMode = event.matches ? "dark" : "light";
+    });
 
-    useEffect(() => {
-        // https://stackoverflow.com/questions/56393880/how-do-i-detect-dark-mode-using-javascript
-        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
-            defaultColorMode = event.matches ? "dark" : "light";
-        });
-    }, [])
-    
-    const [mode, setMode] = useState<any>(defaultColorMode)
+    const [mode, setMode] = useState<'light' | 'dark'>(defaultColorMode)
     const colorMode = useMemo(
         () => ({
             toggleColorMode: () => {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,5 @@
 // information regarding our general greeting information
-// see 
-export const introInfo = {
+const introInfo = {
 	floatingText: "Hey there",
     welcome: "My name is Eduardo, nice to meet you!",
     interest: "I love cats, origami, and coding!",
@@ -8,4 +7,38 @@ export const introInfo = {
     position: "Software Engineer @ Nextdoor",
     major: "Math + Computer Science",
     uni: "University of Illinois",
+}
+
+interface projectLanguages {
+  color: string,
+  name: string,
+}
+
+interface projectRepositoryTopics {
+  topic: {
+    name: string,
+  },
+}
+
+interface projectNode {
+  name: string,
+  stargazerCount: number,
+  url: string,
+  description: string,
+  languages: {
+    nodes: projectLanguages[],
+  },
+  repositoryTopics: {
+    nodes: projectRepositoryTopics[],
+  },
+}
+
+export {
+    introInfo,
+}
+
+export type {
+    projectLanguages,
+    projectRepositoryTopics,
+    projectNode,
 }

--- a/src/lib/getStaticProps.ts
+++ b/src/lib/getStaticProps.ts
@@ -58,6 +58,7 @@ export default async function getStaticProps() {
       })
 
       const { user } = data;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const pinnedItems = await user.pinnedItems.edges.map((edge : any) => edge.node);
       return {
           pinnedItems


### PR DESCRIPTION
# Description
This PR fixes a good issue that @loganlucas13 mentioned while hanging out: the react typed container that contains my introduction is janky, as the container for the React Typed component currently is restricted to be the minimu width of the components. This is bad, as the component grows in size as more texts gets revealed (I assume more of the text elements have the `hidden` css element removed?). But this fixes that!

The PR also introduces more types for our application, and also fixes all lint issues 👍  (the GraphQL does not have a good type import so that will have the ESLint line disabled, and the other two disabled lines are recommended to do in the Next.js documentation!)